### PR TITLE
Add ios support for usePersistentStorage photos

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -428,7 +428,12 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];
             NSData *takenImageData = UIImageJPEGRepresentation(takenImage, quality);
-            NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            NSString *path;
+            if([options[@"usePersistentStorage"] boolValue]) {
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem persistentStorageDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            } else {
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            }
             if (![options[@"doNotSave"] boolValue]) {
                 response[@"uri"] = [RNImageUtils writeImage:takenImageData toPath:path];
             }

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -227,7 +227,7 @@ RCT_CUSTOM_VIEW_PROPERTY(faceDetectionClassifications, NSString, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(barCodeScannerEnabled, BOOL, RNCamera)
 {
-    
+
     view.isReadingBarCodes = [RCTConvert BOOL:json];
     [view setupOrDisableBarcodeScanner];
 }
@@ -239,7 +239,7 @@ RCT_CUSTOM_VIEW_PROPERTY(barCodeTypes, NSArray, RNCamera)
 
 RCT_CUSTOM_VIEW_PROPERTY(textRecognizerEnabled, BOOL, RNCamera)
 {
-    
+
     view.canReadText = [RCTConvert BOOL:json];
     [view setupOrDisableTextDetector];
 }
@@ -263,7 +263,12 @@ RCT_REMAP_METHOD(takePicture,
 #if TARGET_IPHONE_SIMULATOR
             NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
             float quality = [options[@"quality"] floatValue];
-            NSString *path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            NSString *path;
+            if([options[@"usePersistentStorage"] boolValue]) {
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem persistentStorageDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            } else {
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
+            }
             UIImage *generatedPhoto = [RNImageUtils generatePhotoOfSize:CGSizeMake(200, 200)];
             BOOL useFastMode = options[@"fastMode"] && [options[@"fastMode"] boolValue];
             if (useFastMode) {
@@ -355,7 +360,7 @@ RCT_REMAP_METHOD(stopRecording, reactTag:(nonnull NSNumber *)reactTag)
 RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeVideo;
-    
+
     [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
         if (!granted) {
             resolve(@(granted));
@@ -372,7 +377,7 @@ RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(checkVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeVideo;
-    
+
     [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
         resolve(@(granted));
     }];
@@ -388,4 +393,3 @@ RCT_REMAP_METHOD(getAvailablePictureSizes,
 }
 
 @end
-

--- a/ios/RN/RNFileSystem.h
+++ b/ios/RN/RNFileSystem.h
@@ -12,6 +12,6 @@
 + (BOOL)ensureDirExistsWithPath:(NSString *)path;
 + (NSString *)generatePathInDirectory:(NSString *)directory withExtension:(NSString *)extension;
 + (NSString *)cacheDirectoryPath;
++ (NSString *)persistentStorageDirectoryPath;
 
 @end
-

--- a/ios/RN/RNFileSystem.m
+++ b/ios/RN/RNFileSystem.m
@@ -36,5 +36,10 @@
     return [array objectAtIndex:0];
 }
 
-@end
++ (NSString *)persistentStorageDirectoryPath
+{
+    NSArray *array = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    return [array objectAtIndex:0];
+}
 
+@end


### PR DESCRIPTION
As on Android, this flag is photos only, not for video recordings.

I haven't tried running or compiling the code.